### PR TITLE
Fixing the issue where importing a file with extension would fail

### DIFF
--- a/src/path-override.js
+++ b/src/path-override.js
@@ -30,8 +30,11 @@ var getResolvedFile = function (filePath, exts, callback) {
             var componentFileName, componentFilePath;
             // Try to load regular file
             if (extObj.file) {
-                componentFileName = componentId + '.' + extObj.ext;
-                componentFilePath = enclosingDirPath + '.' + extObj.ext;
+                componentFilePath = enclosingDirPath;
+                extension = '.' + extObj.ext;
+                if (componentFilePath.slice(extension.length * -1) !== extension) {
+                    componentFilePath += extension;
+                }
             } else {
                 componentFileName = componentId + '.' + extObj.ext;
                 componentFilePath = path.join(enclosingDirPath, componentFileName);


### PR DESCRIPTION
Fixing the issue where importing a file with extension (such as 'src/messages.json') would fail due to duplicate extension being added.

In our use case, we are trying to use this package for some json files (mostly regarding translations). However, when doing ```import file from './translations/en_US.json'``` it would not be replaced, due to the duplicate extension suffix, causing fs.stat to not find any results.